### PR TITLE
fix optical centering and font weight for the ⏻ icon

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -210,7 +210,7 @@ a:visited {
 
 #power {
   transform: translateY(-2px);
-  font-family: system-ui, 'InterDisplay', 'InterVariable', 'Inter', 'Helvetica Neue', 'Helvetica', Arial, sans-serif;
+  font-family: system-ui,  var(--font-family-base);
 }
 
 @supports (font-variation-settings: normal) {

--- a/css/theme.css
+++ b/css/theme.css
@@ -7,6 +7,8 @@
   color-scheme: light dark;
   --yellow: #FEDB00;
   --violet: #440099;
+  --font-family-base: 'Inter', 'Helvetica Neue', 'Helvetica', Arial, sans-serif;
+  --font-family-variable: 'InterVariable', 'Helvetica Neue', 'Helvetica', Arial, sans-serif;
   font-size: 15px !important;
 }
 
@@ -72,11 +74,11 @@ body {
 
 /* TYPOGRAPHY */
 :root {
-  font-family: 'Inter', 'Helvetica Neue', 'Helvetica', Arial, sans-serif;
+  font-family: var(--font-family-base);
 }
 @supports (font-variation-settings: normal) {
   :root {
-    font-family: 'InterVariable', 'Helvetica Neue', 'Helvetica', Arial, sans-serif;
+    font-family: var(--font-family-variable);
   }
 }
 
@@ -200,6 +202,21 @@ a:visited {
   cursor: wait;
   color: inherit;
   text-decoration: none;
+}
+
+.icon-text {
+  display: block;
+}
+
+#power {
+  transform: translateY(-2px);
+  font-family: system-ui, 'InterDisplay', 'InterVariable', 'Inter', 'Helvetica Neue', 'Helvetica', Arial, sans-serif;
+}
+
+@supports (font-variation-settings: normal) {
+  #power {
+    font-family: system-ui, var(--font-family-variable);
+  }
 }
 
 img {

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
 <body>
 	<r-grid columns=3 columns-s=1 style="max-width: 1000px;">
 		<r-cell span=row>
-			<div id="roundel" class="roundel">CV</div>
+			<div id="roundel" class="roundel"><span class="icon-text" id="cv">CV</span></div>
 			<img id="banner" alt="California Poppies in the afternoon sunlight, growing on the western shoreline of Seattle, Washington. In the background, a cloudy blue sky, and the vague outline of a tree-covered hill." src="img/banners/alki.jpeg">
 			<h1 id="title">
 				<span id="greeting">Hallo,</span> I'm <span class="highlight">Claire&nbsp;Violet</span><span class="rainbow">.</span>

--- a/js/script.js
+++ b/js/script.js
@@ -18,12 +18,29 @@ $(document).ready( function() {
 	}
 	$('#greeting').html(greeting);
 
-	let icons = ['CV','☀','♡','⌘','↪','℅','⏻'];
-
-	$('#roundel').mouseover(function() {
+	let icons = [
+		{ icon: 'CV', id: 'cv' },
+		{ icon: '☀', id: 'sun' },
+		{ icon: '♡', id: 'heart' },
+		{ icon: '⌘', id: 'place-of-interest' },
+		{ icon: '↪', id: 'return' },
+		{ icon: '℅', id: 'care-of' },
+		{ icon: '⏻', id: 'power' }
+	];
+	let isHovering = false;
+	
+	$('#roundel').mouseenter(function() {
+		if (isHovering) return; // prevent multiple rapid fires caused by child element
+		isHovering = true;
+		
 		let rand = Math.floor(Math.random() * icons.length);
-		$('#roundel').html(icons[rand]);
+		$('#roundel').html(`<span class="icon-text" id="${icons[rand].id}">${icons[rand].icon}</span>`);
 	});
+	
+	$('#roundel').mouseleave(function() {
+		isHovering = false;
+	});
+
 
 	$(function () {
 		let returntext = ''

--- a/js/script.js
+++ b/js/script.js
@@ -18,7 +18,7 @@ $(document).ready( function() {
 	}
 	$('#greeting').html(greeting);
 
-	let icons = ['CV','☀','♡','⌘','↪','℅'];
+	let icons = ['CV','☀','♡','⌘','↪','℅','⏻'];
 
 	$('#roundel').mouseover(function() {
 		let rand = Math.floor(Math.random() * icons.length);


### PR DESCRIPTION
addressing this comment:
https://github.com/ctypeh/claire.jetzt/pull/9#issuecomment-3316094139

<img width="2072" height="1256" alt="CleanShot 2025-09-23 at 14 44 39@2x" src="https://github.com/user-attachments/assets/1b94b2c5-712e-4395-b009-116bf0dd91c6" />

- [x] makes the power icon use the system font which allows it to render in SF Black on macOS which better matches Inter Black
- [x] `mouseover` → `mousennter` because there is now a child element
- [x] fixes a bug where child elements cause even `mouseenter` to be overcalled
- [x] optically centers (feel free to adjust to your taste) the power icon